### PR TITLE
Move critical information from rules to key information, minor content fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -436,86 +436,128 @@
                 <div class="card p-4">
                     <div class="card-body">
                         <h2 id="key-information">President's Cup 6 Key Information</h2>
-                        <p>Welcome to the sixth annual President's Cup Cybersecurity Competition! For those of you who
-                            competed
-                            in previous years&mdash;we're glad to have you back. For those of you who are competing for
-                            the first time in President's Cup 6&mdash;we're glad you joined us. Good luck to all
-                            participants, new
-                            and returning.</p>
-                        <p>Here are some important updates to this year's competition:</p>
+                            <p>Welcome to the sixth annual President's Cup Cybersecurity Competition! For those of you who
+                                competed
+                                in previous years&mdash;we're glad to have you back. For those of you who are competing for
+                                the first time in President's Cup 6&mdash;we're glad you joined us. Good luck to all
+                                participants, new
+                                and returning.</p>
+                            <p>Here are some important updates for President's Cup 6:</p>
 
-                       
-			<h3>Cross-Department Teams</h3>
-                        <p>Teams can include participants from <em>different</em> departments and agencies, or join
-                            others across the government wherever they work.</p>
-                        <p>The top 33% of scores in Teams Round 1 will
-                            advance to Round 2. See <a href="#q21"> FAQ #21</a></p>
+                        <h3 id="hours-of-operation">Hours of Operation</h3>
+                            <p>The President's Cup Cybersecurity Competition is open for participation 24/7 during registration and qualifying. Support during registration and qualifying is available:
+                            </p>
+                            <ul>
+                                <li><strong>Registration period</strong>: Monday through Friday, 8:00 AM - 4:00 PM ET</li>
+                                <li><strong>Qualifying rounds</strong>:
+                                    <ul>
+                                        <li>Monday through Friday, 8:00 AM - 11:00 PM ET</li>
+                                        <li>Saturday and Sunday, 9:00 AM - 5:00 PM ET</li>
+                                    </ul>
+                                </li>
+                                <li><strong>Finals</strong>: Support throughout Finals</li>
+                                <li>All noted hours and times are in Eastern Time (ET).</li>
+                            </ul>
+                            <p>The President's Cup email address (<a href="mailto:presidentscup@cisa.dhs.gov">presidentscup@cisa.dhs.gov</a>) will be monitored during normal business hours only (Monday through Friday, 9:00 AM - 5:00 PM ET).</p>
+                            <p><strong>PLEASE NOTE:</strong> Support availability is limited on weekends during the competition (as described in the hours above); <em>participants who choose to compete during this time do so at their own risk.</em> Please make use of the <a href="https://presidentscup.cisa.gov/gb/game/46ce7c07d9ec4a648f9bdd9b08594aef">tutorial challenges</a> to ensure access and compatibility before competing.
+                            </p>
+                          
+                         <h3 id="time-and-challenge-submission-restrictions">Time and Challenge Submission Restrictions</h3>
+                            <ol>
+                                <li>During the qualifying rounds, teams have 6 hours to complete as many challenges as they can. Individuals have 4 hours per track to solve as many challenges as they can.</li>
+                                <li>The session timer runs continuously and once it is started, cannot be paused. This rule applies to both Individuals and Teams. Therefore, teams should schedule their session during a time when all team members are available.</li>
+                                    <ul>
+                                        <li>PLEASE NOTE: For Teams, any team member can start the session.</li>
+                                    </ul>
+                                <li>Your challenge timer does not stop if you "destroy" a challenge space or go work on another challenge. If you start a challenge, then start and work on another challenge, and return to your previous challenge, your challenge timer is still running.</li>
+                                <li>Your round score is determined by the sum of all successful challenges completed during your session. In the event of a tiebreaker, the "Cumulative Time" figure will be used to determine who moves on to the Final Round. The Cumulative Time is the total time spent in challenges successfully solved. This is calculated using a timer specific to each challenge on your game board. When you start a challenge, the timer starts. When you successfully solve a challenge, your score and cumulative time are updated.</li>
+                                <li>Correct answers will vary based on the challenge format and the questions being asked. Please refer to each challenge description which will clearly articulate the format of the answer.</li>
+                                <li>The continuous session timer overview video <a href="#timer-video">can be found here</a>.</li>
+                                    
+                            </ol>
+                                                        
+			            <h3>Cross-Department Teams</h3>
+                            <p>Teams can include participants from <em>different</em> departments and agencies, or join
+                                others across the government wherever they work.</p>
+                            <p>The top 33% of scores in Teams Round 1 will
+                                advance to Round 2. See <a href="#q21"> FAQ #21</a></p>
+
+                        <h3 id="team-composition">Team Composition</h3>
+                            <ol>
+                                <li>Participants can only be on one team and cannot change teams during the competition. Once a team has started the competition, enrollment for the team is locked, and team members <strong>CANNOT</strong> be changed later in the competition.</li>
+                                <li>Team members must be government civilian employees or military service members. Government contractors are <strong>NOT</strong> allowed to participate in the President's Cup.</li>
+                                <li>Teams of <strong>2 to 5</strong> members can be from any federal Executive Branch department or agency, or branch of the Armed Services.</li>
+                                <li>Detailees to an external department can represent their home or detailed department. For example, a member of the Coast Guard detailed to DoD's US Cyber Command can be on a DoD or a DHS team.</li>
+                                <li>Detailees should seek approval of both their home agency and detail supervisor, including agreement on which agency will be responsible for awards.</li>
+                            </ol>
+
+
                         <h3>In-Person Finals Attendance</h3>
-                        <p>All President's Cup finalists must attend the Finals in-person in the Washington DC metropolitan
-                         area in order to participate.</p>
-                        <p>Upon receiving notification that they have qualified for the Finals; competitors must notify
-                            the <a href="mailto:presidentscup@cisa.dhs.gov">President's Cup team</a> whether they will
-                            or will not attend.</p>
-                        <ul>
-                            <li>Team members must respond by February 21, 2025</li>
-                            <li>Individuals must respond by March 7, 2025</li>
-                        </ul>
-                        <p>If finalists are unable to attend, the next highest qualifying individual or team will be
-                            invited. Please note
-                            that entire teams will not be disqualified from participating in the Finals as long as
-                            <em>at least two members</em> attend.
-                        </p>
-			<h3>Bring Your Own Device (BYOD) Policy During the In-Person Finals</h3>
-			<p>Beginning with President's Cup 6, CISA will not be supplying laptops as in previous years.
-			Therefore, all Finalists must <em>bring their own devices to use during the event.</em> This is 
-			now a requirement to participate in the Finals. If you have any questions or concerns, please 
-			contact the <a href="mailto:presidentscup@cisa.dhs.gov">President's Cup team</a>.</p>
-			<h3>Teams Finals</h3>
-			<p>The Teams Finals in President's Cup 6 will take place over the course of a <em>single day</em>, unlike the two-day format used in previous years. As in President's Cup 5, the Teams Finals will include an ICScape Room based upon Industrial Control Systems challenges.</p>
+                            <p>All President's Cup finalists must attend the Finals in-person in the Washington DC metropolitan
+                            area in order to participate.</p>
+                            <p>Upon receiving notification that they have qualified for the Finals; competitors must notify
+                                the <a href="mailto:presidentscup@cisa.dhs.gov">President's Cup team</a> whether they will
+                                or will not attend.</p>
+                            <ul>
+                                <li>Team members must respond by February 21, 2025</li>
+                                <li>Individuals must respond by March 7, 2025</li>
+                            </ul>
+                            <p>If finalists are unable to attend, the next highest qualifying individual or team will be
+                                invited. Please note
+                                that entire teams will not be disqualified from participating in the Finals as long as
+                                <em>at least two members</em> attend.
+                            </p>
+                        <h3>Bring Your Own Device (BYOD) Policy During the In-Person Finals</h3>
+                            <p>Beginning with President's Cup 6, CISA will not be supplying laptops as in previous years.
+                            Therefore, all Finalists must <em>bring their own devices to use during the event.</em> This is 
+                            now a requirement to participate in the Finals. If you have any questions or concerns, please 
+                            contact the <a href="mailto:presidentscup@cisa.dhs.gov">President's Cup team</a>.</p>
+                        <h3>Teams Finals</h3>
+                            <p>The Teams Finals in President's Cup 6 will take place over the course of a <em>single day</em>, unlike the two-day format used in previous years. As in President's Cup 5, the Teams Finals will include an ICScape Room based upon Industrial Control Systems challenges.</p>
                         <h3>Gamespace Package Repositories</h3>
-                        <p>Package repositories from the Internet have been mirrored inside the President's Cup
-                            challenge environment. The current build includes Kali and Python (PyPI). If the default VM
-                            for a challenge does not include a package, you can install
-                            additional ones via the normal commands (<code>apt, pip</code>).</p>
+                            <p>Package repositories from the Internet have been mirrored inside the President's Cup
+                                challenge environment. The current build includes Kali and Python (PyPI). If the default VM
+                                for a challenge does not include a package, you can install
+                                additional ones via the normal commands (<code>apt, pip</code>).</p>
                         <h3>Practice Resources</h3>
-                        <ul>
-                            <li><strong>Practice Area</strong> &#124; The new and improved <a href="/gb/practice"
-                                    target="_blank">Practice Area</a> is a repository of President's Cup challenges from
-                                past competitions. <em> Users can receive a certificate of completion after each
-                                    challenge.</em></li>
-                            <li><strong>Open Source Updates</strong> &#124; The <a
-                                    href="https://github.com/cisagov/prescup-challenges" target="_blank">prescup-challenges</a> GitHub
-                                project has practice resources this year, including solution guides and challenge
-                                code from all previous competitions. <a
-                                    href="https://github.com/cisagov/prescup-challenges/tree/main/pc4/vm" target="_blank">Virtual
-                                    machine builds</a> are also included.</li>
-                        </ul>
+                            <ul>
+                                <li><strong>Practice Area</strong> &#124; The new and improved <a href="/gb/practice"
+                                        target="_blank">Practice Area</a> is a repository of President's Cup challenges from
+                                    past competitions. <em> Users can receive a certificate of completion after each
+                                        challenge.</em></li>
+                                <li><strong>Open Source Updates</strong> &#124; The <a
+                                        href="https://github.com/cisagov/prescup-challenges" target="_blank">prescup-challenges</a> GitHub
+                                    project has practice resources this year, including solution guides and challenge
+                                    code from all previous competitions. <a
+                                        href="https://github.com/cisagov/prescup-challenges/tree/main/pc4/vm" target="_blank">Virtual
+                                        machine builds</a> are also included.</li>
+                            </ul>
                         <h3>Gameboard Features</h3>
-                        <ul>
-                            <li><strong>Support Inside Gameboard</strong> &#124; <a href="/gb/support/tickets">Competition
-                                    support</a> is now integrated within the Gameboard web app. Participants can create
-                                support tickets from a deployed challenge or from the <strong>Support</strong> link
-                                at the top of the gameboard. The Support link is where participants view, update,
-                                and
-                                track the status of support tickets. When created from a deployed challenge, new tickets
-                                already include the challenge name, support code, and game.</li>
-                            <li><strong>Round Completion Certificates</strong> &#124; When each round of the competition is
-                                over, participants can view and print <a
-                                    href="/gb/user/certificates/competitive">completion certificates</a> of their
-                                achievement. Certificates will be available from the <strong>Profile</strong> page in
-                                the Gameboard.
-                            </li>
-                        </ul>
+                            <ul>
+                                <li><strong>Support Inside Gameboard</strong> &#124; <a href="/gb/support/tickets">Competition
+                                        support</a> is now integrated within the Gameboard web app. Participants can create
+                                    support tickets from a deployed challenge or from the <strong>Support</strong> link
+                                    at the top of the Gameboard. The Support link is where participants view, update,
+                                    and
+                                    track the status of support tickets. When created from a deployed challenge, new tickets
+                                    already include the challenge name, support code, and game.</li>
+                                <li><strong>Round Completion Certificates</strong> &#124; When each round of the competition is
+                                    over, participants can view and print <a
+                                        href="/gb/user/certificates/competitive">completion certificates</a> of their
+                                    achievement. Certificates will be available from the <strong>Profile</strong> page in
+                                    the Gameboard.
+                                </li>
+                            </ul>
                         <h3>Final Words</h3>
-                        <p>Please review <em>all</em> of the <a href="#rules">rules</a>, <a href="#faq">FAQs</a>, and <a
-                                href="#videos">videos</a>
-                            before starting the competition, but pay particular attention to:</p>
-                        <ul>
-                            <li><a href="#q0">FAQ #0: What does "Cumulative Time" mean on the leaderboard?</a></li>
-                            <li><a href="#q3">FAQ #3: How does each round's continuous session timer work?</a></li>
-                        </ul>
-                        <p>Thank you all for your participation and best of luck in President's Cup 6!
-                        </p>
+                            <p>Please review <em>all</em> of the <a href="#rules">rules</a>, <a href="#faq">FAQs</a>, and <a
+                                    href="#videos">videos</a>
+                                before starting the competition, but pay particular attention to:</p>
+                            <ul>
+                                <li><a href="#q0">FAQ #0: What does "Cumulative Time" mean on the leaderboard?</a></li>
+                                <li><a href="#q3">FAQ #3: How does each round's continuous session timer work?</a></li>
+                            </ul>
+                            <p>Thank you all for your participation and best of luck in President's Cup 6!
+                            </p>
                     </div>
                 </div>
             </div>
@@ -686,50 +728,8 @@
 				includes both subscription and licensed services.</li>
                         
 			</ol>
-                        <h3 id="team-composition">Team Composition</h3>
-                        <ol>
-                            <li>Participants can only be on one team and cannot change teams during the competition.
-                                Once a team has started the competition, enrollment for the team is locked,
-                                and team members <strong>CANNOT</strong> be changed
-                                later
-                                in the competition.</li>
-                            <li>Teams of <strong>2 to 5 members</strong> can be from any federal Executive Branch
-                                department or agency, or branch of the Armed Services.</li>
-                            <li>Detailees to an external department can represent their home or detailed department.
-                                For
-                                example, a member of the Coast Guard detailed to DoD's US Cyber Command can be on a
-                                DoD
-                                or a DHS team. </li>
-                            <li>Detailees should seek approval of both their home agency and detail
-                                supervisor, including agreement on which agency will be responsible for awards.</li>
-                            <li>Team members must be government civilian employees or military service members.
-                                Government contractors are <strong>NOT</strong> allowed to participate in the
-                                President's Cup Competition. </li>
-                        </ol>
-                        <h3 id="time-and-challenge-submission-restrictions">Time and Challenge Submission
-                            Restrictions
-                        </h3>
-                        <ol>
-                            <li>During the qualifying rounds, teams have <strong>6 hours</strong> to complete as
-                                many
-                                challenges as they can. Individuals have <strong>4 hours</strong> per track to solve
-                                as
-                                many challenges as they can.</li>
-                            <li>In the event of a tiebreaker, the "Cumulative Time" figure will be used to determine
-                                who
-                                moves on to the Final Round. The Cumulative Time is the total time spent in
-                                challenges
-                                successfully solved. This is calculated using a timer specific to each challenge on
-                                your
-                                game board. When you start a challenge, the timer starts. When you successfully
-                                solve a
-                                challenge, your score and cumulative time are updated.</li>
-                            <li>Correct answers will vary based on the challenge format and the questions being
-                                asked.
-                                Please refer to each challenge description which will clearly articulate the format
-                                of
-                                the answer.</li>
-                        </ol>
+
+                       
                         <h3 id="registration">Registration</h3>
                         <ul>
                             <li><strong>Teams:</strong> Starts at 9:00 AM ET on December 9, 2024, and ends at 11:59 PM
@@ -743,7 +743,7 @@
                             <li>Registration for the President's Cup will close after the specified dates and times.</li>
                         </ul>
                         <h3 id="support-and-contact-information">Support and Contact Information</h3>
-                        <p>Support requests are tracked in the <a href="/gb/support/tickets">President's Cup gameboard
+                        <p>Support requests are tracked in the <a href="/gb/support/tickets">President's Cup Gameboard
                                 support interface (an integrated ticketing service)</a>. Participants
                             create support tickets from a deployed challenge or from the new <strong>Support</strong>
                             link in the navigation bar. Navigate to this location within the game to view a ticket's
@@ -760,35 +760,9 @@
                             opposed to requests for technical support.
                         </p>
 
-			<p><strong>PLEASE NOTE:</strong> Helpdesk support will be unavailable from <strong>Monday, December 23,</strong>
-			through <strong>Wednesday, January 1</strong>. Any inquires received during this time will be addressed starting on <strong>January 2</strong>. </p>
+			            <p><strong>PLEASE NOTE:</strong> Helpdesk support will be unavailable from <strong>Monday, December 23,</strong> through <strong>Wednesday, January 1</strong>. Any inquires received during this time will be addressed starting on <strong>January 2</strong>.</p>
 
-                        <h3 id="hours-of-operation">Hours of Operation</h3>
-                        <p>The President's Cup Cybersecurity Competition is open for participation 24/7 during
-                            registration and qualifying. Support during registration and qualifying is available:
-                        </p>
-                        <ul>
-                            <li><strong>Registration period</strong>: Monday through Friday, 8:00 AM - 4:00 PM ET</li>
-                            <li><strong>Qualifying rounds</strong>:
-                                <ul>
-                                    <li>Monday through Friday, 8:00 AM - 11:00 PM ET</li>
-                                    <li>Saturday and Sunday, 9:00 AM - 5:00 PM ET</li>
-                                </ul>
-                            </li>
-                            <li><strong>Finals</strong>: Support throughout Finals</li>
-                            <li>All noted hours and times are in Eastern Time (ET).</li>
-                        </ul>
-                        <p>The President's Cup email address (<a
-                                href="mailto:presidentscup@cisa.dhs.gov">presidentscup@cisa.dhs.gov</a>) will be monitored 
-			during normal business hours only (Monday through Friday, 9:00 AM - 5:00 PM ET).</p>
-                        <p><strong>PLEASE NOTE:</strong> Support availability is limited on weekends during the
-                            competition (as described in the hours above);
-                            <em>participants who choose to compete during this time do so at their own risk.</em> Please
-                            make
-                            use
-                            of the <a href="/gb/game/46ce7c07d9ec4a648f9bdd9b08594aef">tutorial challenges</a> to
-                            ensure access and compatibility before competing.
-                        </p>
+  
                     </div>
                 </div>
             </div>
@@ -799,8 +773,7 @@
                 <div class="card p-4">
                     <div class="card-body">
                         <h2 id="faq">Frequently Asked Questions (FAQ)</h2>
-                        <p>Below you will find some commonly asked questions and answers to help you with the
-                            competition. If you can't find the answer here, please contact us.</p>
+                        <p>Below you will find some commonly asked questions and answers to help you with the President's Cup. If you can't find the answer here, please contact us.</p>
                         <ol class="questions ps-0" start="0">
                             <li><a href="#q0">What does "Cumulative Time" mean on the leaderboard?</a></li>
                             <li><a href="#q1">I'm a government contractor and I want to participate. Am I
@@ -910,7 +883,7 @@
                                     welcome page. After starting the session, you/your team will have a limited amount
                                     of time to complete as many
                                     challenges as you can.</p>
-                                <p>The session time limits for the Presidents Cup Competition are:</p>
+                                <p>The session time limits for the President's Cup Competition are:</p>
                                 <table class="table table-primary table-striped">
                                     <thead>
                                         <tr>
@@ -984,8 +957,8 @@
                             <div>
                                 <p class="question">I saw that the Finals are an in-person event.
                                     Where are the Finals held?</p>
-                                <p>The 2024 Finals will be held in the Washington DC metropolitan area. The specific
-				facility is to be decided (TBD), and determiniation will be made in the coming months. 
+                                <p>The Finals will be held in the Washington DC metropolitan area. The specific
+				facility is to be decided (TBD), and determination will be made in the coming months. 
 				Participants are responsible for travel if they qualify.</p>
                             </div>
                         </div>
@@ -1027,7 +1000,7 @@
                             <div>
                                 <p class="question">When does registration for the President's Cup Competition start?</p>
                                 <p>Registration for President's Cup 6 Competition opens on Monday, December 9th and closes 
-                                   on Tuesday, January 14th for Teams and Tuesday, Janurary 28th for Individuals.</p>
+                                   on Tuesday, January 14th for Teams and Tuesday, January 28th for Individuals.</p>
                             </div>
                         </div>
 


### PR DESCRIPTION
Move some of the most critical information from the Rules area higher on the page to the Key Information section, update all references of the "2024 competition" to simply "the competition" or "President's Cup", and fix a few spelling and grammar errors.

All changes noted in the attached document.

[Competition Site Language Updates for PCVI_1.21.25 Updates.docx](https://github.com/user-attachments/files/18495796/Competition.Site.Language.Updates.for.PCVI_1.21.25.Updates.docx)