### PR TITLE
Added FAQ #32, anchor link and FAQ content

### DIFF
--- a/index.html
+++ b/index.html
@@ -835,6 +835,7 @@
                                     than my email address (e.g., a TOTP application)?</a></li>
                             <li><a href="#q31">My email address has changed. Can I add an email address to my 
                                     existing account?</a></li>
+                            <li><a href="#q32">How do I perform a password reset on my Gameboard account?</a></li>
                         </ol>
 
                         <hr />
@@ -1331,6 +1332,16 @@
                                         <a href="mailto:presidentscup@cisa.dhs.gov">presidentscup@cisa.dhs.gov</a> 
                                         to have your new email address added to your account.
                                     </em>
+                                </p>
+                            </div>
+                        </div>
+                        <div id="q32" class="faq mb-4">
+                            <div class="mr-4">32.</div>
+                            <div>
+                                <p class="question">
+                                    How do I perform a password reset on my Gameboard account?
+                                </p>
+                                <p>If you need to reset your Gameboard password, please navigate to your <a target="_blank" href="https://presidentscup.cisa.gov/id/">President's Cup ID</a> page, click the <em>Login</em> button, and then <em>Reset My Password</em>.  You will then receive an email at the email address that you used to sign up with instructions for resetting your password.  After resetting your password, you will be able to access the <a href="https://presidentscup.cisa.gov/gb" target="_blank">President's Cup Gameboard</a> with the new password that you created. 
                                 </p>
                             </div>
                         </div>


### PR DESCRIPTION
Added FAQ #32: "How do I perform a password reset on my Gameboard account?" along with the corresponding anchor link in the FAQ list.

![President-s-Cup-VI-02-04-2025_12_27_PM](https://github.com/user-attachments/assets/f3f1ab17-bad5-42b7-a988-d0db09e064b5)