### PR TITLE
Clarified FAQ number 28 to remove references to installing additional tools in non-default Kali VM

### DIFF
--- a/index.html
+++ b/index.html
@@ -835,6 +835,7 @@
                                     than my email address (e.g., a TOTP application)?</a></li>
                             <li><a href="#q31">My email address has changed. Can I add an email address to my 
                                     existing account?</a></li>
+                            <li><a href="#q32">How do I perform a password reset on my Gameboard account?</a></li>
                         </ol>
 
                         <hr />
@@ -1331,6 +1332,16 @@
                                         <a href="mailto:presidentscup@cisa.dhs.gov">presidentscup@cisa.dhs.gov</a> 
                                         to have your new email address added to your account.
                                     </em>
+                                </p>
+                            </div>
+                        </div>
+                        <div id="q32" class="faq mb-4">
+                            <div class="mr-4">32.</div>
+                            <div>
+                                <p class="question">
+                                    How do I perform a password reset on my Gameboard account?
+                                </p>
+                                <p>If you need to reset your Gameboard password, please navigate to your <a target="_blank" href="https://presidentscup.cisa.gov/id/">President's Cup ID</a> page, click the <em>Login</em> button, and then <em>Reset My Password</em>.  You will then receive an email at the email address that you used to sign up with instructions for resetting your password.  After resetting your password, you will be able to access the <a href="https://presidentscup.cisa.gov/gb" target="_blank">President's Cup Gameboard</a> with the new password that you created. 
                                 </p>
                             </div>
                         </div>

--- a/index.html
+++ b/index.html
@@ -1249,10 +1249,7 @@
                                     environment.
                                     Internet connectivity is removed to keep the integrity of the competition and ensure
                                     there
-                                    is a level playing field for all participants. Mirrors of standard application
-                                    repositories
-                                    (Apt and Pip) are provided for use inside of the challenge environment to
-                                    install additional tools on the provided virtual machines.
+                                    is a level playing field for all participants.
                                 </p>
                             </div>
                         </div>


### PR DESCRIPTION
Removed the following from FAQ number 28:

Mirrors of standard application repositories (Apt and Pip) are provided for use inside of the challenge environment to install additional tools on the provided virtual machines.